### PR TITLE
Enable client auth on kubelet

### DIFF
--- a/recipes/minion.rb
+++ b/recipes/minion.rb
@@ -35,6 +35,12 @@ if node['kubernetes']['secure']['enabled'] == 'true'
     group 'kube-services'
     mode '0770'
   end
+  file "#{node['kubernetes']['secure']['directory']}/client.srv.bundle.crt" do
+    content "#{node['kubernetes']['etcd']['client']['cert']}\n#{node['kubernetes']['etcd']['client']['ca']}"
+    owner 'root'
+    group 'kube-services'
+    mode '0770'
+  end
   file "#{node['kubernetes']['secure']['directory']}/client.srv.key" do
     content node['kubernetes']['etcd']['client']['key']
     owner 'root'

--- a/templates/default/kube-kubelet.erb
+++ b/templates/default/kube-kubelet.erb
@@ -11,5 +11,5 @@ KUBELET_ARGS="--register-node=true <% if @pause_container -%>--pod_infra_contain
 # Secure kubelet configuration parameters go under here when node['kubernetes']['secure']['enabled'] == 'true'
 <% if node['kubernetes']['secure']['enabled'] == 'true' -%>
 KUBELET_API_SERVER="--api_servers=https://127.0.0.1:<%= @kubernetes_secure_api_port %>"
-KUBELET_ARGS="--register-node=true <% if @pause_container -%>--pod_infra_container_image=<%= @pause_container %><% end -%> --kubeconfig=<%= @etcd_cert_dir %>/kube.config"
+KUBELET_ARGS="--register-node=true <% if @pause_container -%>--pod_infra_container_image=<%= @pause_container %><% end -%> --kubeconfig=<%= @etcd_cert_dir %>/kube.config --tls-cert-file=<%= @etcd_cert_dir %>/client.srv.bundle.crt --tls-private-key-file=<%= @etcd_cert_dir %>/client.srv.key"
 <% end -%>


### PR DESCRIPTION
Currently, it looks like the kubelet port (implicitly open since `--port` is not specified) is not enforcing client auth, even though it looks like kube-apiserver is configured to provide a client cert to it.

These are the flags, and the cert bundle setup I'm currently using, but I haven't tested it via this cookbook yet.