### PR TITLE
Flannel networking: finding etcd

### DIFF
--- a/recipes/flanneld.rb
+++ b/recipes/flanneld.rb
@@ -27,6 +27,7 @@ template '/etc/sysconfig/flanneld' do
   mode '0640'
   source 'flannel-flanneld.erb'
   variables(
+    kubernetes_master: node['kubernetes']['master']['fqdn'],
     etcd_client_port: node['kubernetes']['etcd']['clientport'],
     etcd_cert_dir: node['kubernetes']['secure']['directory']
   )

--- a/templates/default/flannel-flanneld.erb
+++ b/templates/default/flannel-flanneld.erb
@@ -4,11 +4,11 @@ FLANNEL_ETCD_KEY="/coreos.com/network"
 
 # Secure ETCD configuration parameters go under here when node['kubernetes']['secure']['enabled'] == 'false'
 <% if node['kubernetes']['secure']['enabled'] == 'false' -%>
-FLANNEL_ETCD="http://127.0.0.1:<%= @etcd_client_port %>"
+FLANNEL_ETCD="http://<%= @kubernetes_master %>:<%= @etcd_client_port %>"
 <% end -%>
 
 # Secure ETCD configuration parameters go under here when node['kubernetes']['secure']['enabled'] == 'true'
 <% if node['kubernetes']['secure']['enabled'] == 'true' -%>
-FLANNEL_ETCD="https://127.0.0.1:<%= @etcd_client_port %>"
+FLANNEL_ETCD="https://<%= @kubernetes_master %>:<%= @etcd_client_port %>"
 FLANNEL_OPTIONS="--etcd-certfile=<%= @etcd_cert_dir %>/client.srv.crt --etcd-keyfile=<%= @etcd_cert_dir %>/client.srv.key --etcd-cafile=<%= @etcd_cert_dir %>/client.ca.crt"
 <% end -%>

--- a/templates/default/flannel-flanneld.erb
+++ b/templates/default/flannel-flanneld.erb
@@ -4,11 +4,11 @@ FLANNEL_ETCD_KEY="/coreos.com/network"
 
 # Secure ETCD configuration parameters go under here when node['kubernetes']['secure']['enabled'] == 'false'
 <% if node['kubernetes']['secure']['enabled'] == 'false' -%>
-FLANNEL_ETCD="http://<%= @kubernetes_master %>:<%= @etcd_client_port %>"
+FLANNEL_ETCD="<% @kubernetes_master.each_with_index do |node, i| %><%= i > 0 ? ',' : '' %>http://<%= node %>:<%= @etcd_client_port %><% end %>"
 <% end -%>
 
 # Secure ETCD configuration parameters go under here when node['kubernetes']['secure']['enabled'] == 'true'
 <% if node['kubernetes']['secure']['enabled'] == 'true' -%>
-FLANNEL_ETCD="https://<%= @kubernetes_master %>:<%= @etcd_client_port %>"
+FLANNEL_ETCD="<% @kubernetes_master.each_with_index do |node, i| %><%= i > 0 ? ',' : '' %>https://<%= node %>:<%= @etcd_client_port %><% end %>"
 FLANNEL_OPTIONS="--etcd-certfile=<%= @etcd_cert_dir %>/client.srv.crt --etcd-keyfile=<%= @etcd_cert_dir %>/client.srv.key --etcd-cafile=<%= @etcd_cert_dir %>/client.ca.crt"
 <% end -%>


### PR DESCRIPTION
We have previously been seeing that nodes were not able to talk to containers on different nodes using the pod's cluster IP. We have also seen that flannel was unable to start during reboot because it couldn't connect to etcd.

In these changes I point the `FLANNEL_ETCD` config at the kubernetes master nodes, where etcd resides.

On our minions we define `kubernetes.master.fqdn = ["hostname"]` as per the readme. On the master node we weren't previously doing this and the default value of `kubernetes.master.fqdn` was a _string_, which caused problems. I'm now explicitly setting this config option on the masters too to ensure that it's in the same format as on the minions.

This change assumes `kubernetes.master.fqdn` is an array of strings, so before merging we should probably change the fqdn default to an array, or require it to be specified in all cases.