### PR TITLE
Ability to configure multiple Docker registries in /etc/sysconfig/docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project will adhere to strict
 [Semantic Versioning](http://semver.org/) starting at v1.0.0.
 
+## 1.1.0
+- Able to configure multiple registries in docker config
+
 ## 1.0.7
 - Fix bug with insecure podmaster connecting to wrong port
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'drapenchuk@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook for installing and configuring a Kubernetes cluster.'
 long_description 'Application cookbook for installing and configuring a Kubernetes cluster.'
-version '1.0.7'
+version '1.1.0'
 
 %w(centos redhat).each do |name|
   supports name, '~> 7.1'

--- a/templates/default/docker.erb
+++ b/templates/default/docker.erb
@@ -2,6 +2,6 @@
 
 OPTIONS='--selinux-enabled<% if @docker_basedir -%> -g <%= @docker_basedir %><% end -%>'
 DOCKER_CERT_PATH=/etc/docker
-<% if @docker_registry -%>ADD_REGISTRY='--add-registry <%= @docker_registry %>'<% end -%>
-<% if @docker_insecureregistry -%>INSECURE_REGISTRY='--insecure-registry <%= @docker_insecureregistry %>'<% end -%>
+<% if @docker_registry -%>ADD_REGISTRY='<% if @docker_registry.kind_of?(Array) -%><% @docker_registry.each do |name| -%> --add-registry <%= name %><% end -%><% else -%> --add-registry <%= @docker_registry %><% end -%>'<% end %>
+<% if @docker_insecureregistry -%>INSECURE_REGISTRY='<% if @docker_insecureregistry.kind_of?(Array) -%><% @docker_insecureregistry.each do |name| -%> --insecure-registry <%= name %><% end -%><% else -%> --insecure-registry <%= @docker_insecureregistry %><% end -%>'<% end %>
 DOCKER_TMPDIR=<% if @docker_basedir -%><%= @docker_basedir %><% end -%>/tmp


### PR DESCRIPTION
Tests if docker_registry or docker_insecureregistry are set in resource:
  - If set
    - If array
      - write out entry for each item
    - Else
      - write out entry for string

Tested on:
EL7.2 cluster on Openstack
EL7.1 cluster on VMWare
EL7.2 cluster on AWS